### PR TITLE
Wildcard mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to autoxpose will be documented in this file.
+
+## [0.4.0] - 2026-02-04
+
+### Added
+
+- **Wildcard Mode**: Skip individual DNS record creation when using wildcard DNS and SSL certificates
+  - **[sub]** Auto-detect `*.domain.com` certificates from NPM
+  - **[sub]** DNS credentials no longer required when wildcard mode is active
+
+- **Portracker Integration**: Expose data for portracker to display publicly accessible services
+  - **[sub]** `/api/services?includeExternal=true` returns all exposed services including manually configured ones
+
+---
+
+## [0.3.0] - 2026-02-03
+
+**Highlights**
+
+- Service Tags - Auto-categorize services with GitHub topics inference
+- DDNS Support - Dynamic IP hostname resolution for CNAME records
+- Orphaned Resource Cleanup - Detect and remove stale DNS records and proxy hosts
+
+---
+
+### Added
+
+- **Service Tags**: Auto-categorize services (web, database, media, etc.) with color-coded badges
+  - **[sub]** GitHub topics inference for automatic tag assignment
+  - **[sub]** Custom tags via inline editing
+
+- **DDNS/CNAME Support**: Dynamic IP hostname resolution for users with changing public IPs
+
+- **Orphaned Resource Cleanup**: Detect and clean up stale DNS records and proxy hosts
+
+### Fixed
+
+- **DNS Record Recreation**: Fixed recreation after external deletion
+- **SSL Retry**: Update service state correctly after SSL retry success
+
+---
+
+## [0.2.0] - 2026-01-20
+
+**Highlights**
+
+- Network Topology Visualizer - Interactive network graph of services
+- Service Renaming - Inline editing for service names
+
+---
+
+### Added
+
+- **Network Topology Visualizer**: Interactive graph showing service connections and relationships
+
+- **Service Renaming**: Inline editing to rename services from the dashboard
+
+- **Keyboard Shortcuts**: Modal showing available shortcuts for power users
+
+### Fixed
+
+- **Subdomain Preservation**: Preserve user-edited subdomains during container rescan
+
+---
+
+## [0.1.0] - 2026-01-10
+
+### Initial Release
+
+- **Automatic Discovery**: Scan Docker containers for autoxpose labels
+- **DNS Management**: Create and remove DNS records with propagation verification
+- **SSL & Scheme Auto-Detection**: Automatic HTTPS detection and SSL certificate management
+- **Auto-Expose Mode**: Automatically expose services with `autoxpose.enable=auto`
+- **Supported Providers**: Cloudflare, Netlify, DigitalOcean, Porkbun (DNS); NPM, Caddy (Proxy)
+- **Terminal UI**: Interactive terminal interface for configuration and management

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoxpose",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/backend/src/features/expose/streaming-expose.service.ts
+++ b/packages/backend/src/features/expose/streaming-expose.service.ts
@@ -161,8 +161,7 @@ export class StreamingExposeService {
   }
 
   private async getBaseDomain(): Promise<string | null> {
-    const cfg = await this.settings.getDnsConfig();
-    return cfg?.config.domain ?? null;
+    return this.settings.getBaseDomainFromAnySource();
   }
 
   private async determineScheme(

--- a/packages/backend/src/features/proxy/proxy.types.ts
+++ b/packages/backend/src/features/proxy/proxy.types.ts
@@ -23,6 +23,7 @@ export type CreateProxyHostInput = {
   targetScheme?: 'http' | 'https';
   ssl?: boolean;
   skipDnsWait?: boolean;
+  certificateId?: number;
 };
 
 export type UpdateProxyHostInput = {

--- a/packages/backend/src/features/services/ssl.routes.ts
+++ b/packages/backend/src/features/services/ssl.routes.ts
@@ -18,13 +18,13 @@ export const createSslRoutes = (ctx: AppContext): FastifyPluginAsync => {
       if (!service) return notFound(reply);
       if (!service.subdomain) return badRequest(reply, 'Service has no subdomain');
 
-      const dns = await ctx.settings.getDnsConfig();
-      if (!dns?.config.domain) return badRequest(reply, 'No DNS domain configured');
+      const baseDomain = await ctx.settings.getBaseDomainFromAnySource();
+      if (!baseDomain) return badRequest(reply, 'No domain configured');
 
       const proxy = await ctx.settings.getProxyProvider();
       if (!proxy) return badRequest(reply, 'No proxy provider configured');
 
-      const fqdn = `${service.subdomain}.${dns.config.domain}`;
+      const fqdn = `${service.subdomain}.${baseDomain}`;
       const host = await proxy.findByDomain(fqdn);
       if (!host) return badRequest(reply, 'No proxy host found for this service');
 

--- a/packages/backend/src/features/services/sync-helpers.ts
+++ b/packages/backend/src/features/services/sync-helpers.ts
@@ -1,4 +1,11 @@
+import type { DnsRecord } from '../dns/dns.types.js';
 import type { ProxyHost } from '../proxy/proxy.types.js';
+
+interface ServiceForMatching {
+  subdomain: string;
+  name: string;
+  port: number;
+}
 
 export function fuzzyMatchSubdomain(subdomain: string, containerName: string): boolean {
   const sub = subdomain.toLowerCase();
@@ -19,5 +26,47 @@ export function getExposedSubdomain(
   baseDomain: string
 ): string | null {
   if (!proxyHost) return null;
-  return baseDomain ? proxyHost.domain.replace(`.${baseDomain}`, '') : proxyHost.domain;
+  if (!baseDomain) return proxyHost.domain;
+  if (!proxyHost.domain.endsWith(`.${baseDomain}`)) return null;
+  return proxyHost.domain.replace(`.${baseDomain}`, '');
+}
+
+export function findMatchingDnsRecord(
+  service: ServiceForMatching,
+  records: DnsRecord[],
+  baseDomain: string
+): DnsRecord | undefined {
+  const exactDomain = baseDomain ? `${service.subdomain}.${baseDomain}` : service.subdomain;
+  const exactMatch = records.find(r => r.hostname === exactDomain && r.type === 'A');
+  if (exactMatch) return exactMatch;
+
+  const recordsOnDomain = baseDomain
+    ? records.filter(r => r.hostname.endsWith(`.${baseDomain}`))
+    : records;
+
+  return recordsOnDomain.find(r => {
+    if (r.type !== 'A') return false;
+    const recordSub = baseDomain ? r.hostname.replace(`.${baseDomain}`, '') : r.hostname;
+    return recordSub && fuzzyMatchSubdomain(recordSub, service.name);
+  });
+}
+
+export function findMatchingProxyHost(
+  service: ServiceForMatching,
+  hosts: ProxyHost[],
+  baseDomain: string
+): ProxyHost | undefined {
+  const exactDomain = baseDomain ? `${service.subdomain}.${baseDomain}` : service.subdomain;
+  const exactMatch = hosts.find(h => h.domain === exactDomain);
+  if (exactMatch) return exactMatch;
+
+  const hostsOnDomain = baseDomain ? hosts.filter(h => h.domain.endsWith(`.${baseDomain}`)) : hosts;
+
+  const fuzzyMatch = hostsOnDomain.find(h => {
+    const hostSub = baseDomain ? h.domain.replace(`.${baseDomain}`, '') : h.domain;
+    return hostSub && fuzzyMatchSubdomain(hostSub, service.name);
+  });
+  if (fuzzyMatch) return fuzzyMatch;
+
+  return hostsOnDomain.find(h => h.targetPort === service.port);
 }

--- a/packages/backend/src/features/settings/settings.repository.ts
+++ b/packages/backend/src/features/settings/settings.repository.ts
@@ -12,9 +12,16 @@ export interface ProviderConfigRecord {
 }
 
 export interface SaveProviderInput {
-  type: 'dns' | 'proxy';
+  type: 'dns' | 'proxy' | 'wildcard';
   provider: string;
-  config: Record<string, string>;
+  config: Record<string, unknown>;
+}
+
+export interface WildcardConfig {
+  enabled: boolean;
+  domain: string;
+  certId: number | null;
+  detectedAt: string | null;
 }
 
 export class SettingsRepository {
@@ -70,5 +77,21 @@ export class SettingsRepository {
       .delete(schema.providerConfigs)
       .where(eq(schema.providerConfigs.type, type));
     return result.changes > 0;
+  }
+
+  async getWildcardConfig(): Promise<WildcardConfig | null> {
+    const record = await this.getByType('wildcard');
+    if (!record) return null;
+    const parsed = JSON.parse(record.config) as WildcardConfig;
+    return parsed;
+  }
+
+  async saveWildcardConfig(config: WildcardConfig): Promise<WildcardConfig> {
+    await this.save({
+      type: 'wildcard',
+      provider: 'wildcard',
+      config: config as unknown as Record<string, unknown>,
+    });
+    return config;
   }
 }

--- a/packages/frontend/src/components/terminal/config/dns-form.tsx
+++ b/packages/frontend/src/components/terminal/config/dns-form.tsx
@@ -1,0 +1,262 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { api, type SettingsStatus } from '../../../lib/api';
+import { FormActions, FormInput, FormSelect } from '../form-components';
+import { TestConnectionButton, type TestState } from '../test-button';
+
+export const DNS_PROVIDERS = [
+  { value: 'cloudflare', label: 'Cloudflare' },
+  { value: 'netlify', label: 'Netlify' },
+  { value: 'digitalocean', label: 'DigitalOcean' },
+  { value: 'porkbun', label: 'Porkbun' },
+];
+
+interface DnsFieldsProps {
+  provider: string;
+  token: string;
+  zoneId: string;
+  domain: string;
+  apiKey: string;
+  secretKey: string;
+  hasToken: boolean;
+  hasApiKey: boolean;
+  onProviderChange: (v: string) => void;
+  onTokenChange: (v: string) => void;
+  onZoneIdChange: (v: string) => void;
+  onDomainChange: (v: string) => void;
+  onApiKeyChange: (v: string) => void;
+  onSecretKeyChange: (v: string) => void;
+}
+
+function PorkbunFields(props: {
+  apiKey: string;
+  secretKey: string;
+  apiKeyPlaceholder: string;
+  onApiKeyChange: (v: string) => void;
+  onSecretKeyChange: (v: string) => void;
+}): JSX.Element {
+  return (
+    <>
+      <FormInput
+        label="API Key"
+        type="password"
+        placeholder={props.apiKeyPlaceholder}
+        value={props.apiKey}
+        onChange={props.onApiKeyChange}
+      />
+      <FormInput
+        label="Secret Key"
+        type="password"
+        placeholder="Enter secret key"
+        value={props.secretKey}
+        onChange={props.onSecretKeyChange}
+      />
+    </>
+  );
+}
+
+function DnsFormFields(props: DnsFieldsProps): JSX.Element {
+  const isPorkbun = props.provider === 'porkbun';
+  const needsZone = props.provider === 'cloudflare' || props.provider === 'netlify';
+  const tokenPlaceholder = props.hasToken ? 'Saved' : 'Enter token';
+  const apiKeyPlaceholder = props.hasApiKey ? 'Saved' : 'Enter API key';
+
+  return (
+    <>
+      <FormInput
+        label="Base Domain"
+        placeholder="example.com"
+        value={props.domain}
+        onChange={props.onDomainChange}
+      />
+      <FormSelect
+        label="Provider"
+        value={props.provider}
+        onChange={props.onProviderChange}
+        options={DNS_PROVIDERS}
+      />
+      {isPorkbun ? (
+        <PorkbunFields
+          apiKey={props.apiKey}
+          secretKey={props.secretKey}
+          apiKeyPlaceholder={apiKeyPlaceholder}
+          onApiKeyChange={props.onApiKeyChange}
+          onSecretKeyChange={props.onSecretKeyChange}
+        />
+      ) : (
+        <FormInput
+          label="API Token"
+          type="password"
+          placeholder={tokenPlaceholder}
+          value={props.token}
+          onChange={props.onTokenChange}
+        />
+      )}
+      {needsZone && (
+        <FormInput
+          label="Zone ID"
+          placeholder="Zone ID"
+          value={props.zoneId}
+          onChange={props.onZoneIdChange}
+        />
+      )}
+    </>
+  );
+}
+
+type DnsFormState = {
+  provider: string;
+  token: string;
+  zoneId: string;
+  domain: string;
+  apiKey: string;
+  secretKey: string;
+  isPending: boolean;
+  isError: boolean;
+  mutate: () => void;
+  isConfigured: boolean;
+  canSave: boolean;
+  setProvider: (v: string) => void;
+  setToken: (v: string) => void;
+  setZoneId: (v: string) => void;
+  setDomain: (v: string) => void;
+  setApiKey: (v: string) => void;
+  setSecretKey: (v: string) => void;
+  hasToken: boolean;
+  hasApiKey: boolean;
+};
+
+function useDnsForm(current: SettingsStatus['dns'] | null, onDone: () => void): DnsFormState {
+  const [provider, setProvider] = useState(current?.provider || 'cloudflare');
+  const [token, setToken] = useState('');
+  const [zoneId, setZoneId] = useState(current?.config?.zoneId || '');
+  const [domain, setDomain] = useState(current?.domain || '');
+  const [apiKey, setApiKey] = useState('');
+  const [secretKey, setSecretKey] = useState('');
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (current?.provider) setProvider(current.provider);
+    if (current?.config?.zoneId) setZoneId(current.config.zoneId);
+    if (current?.domain) setDomain(current.domain);
+  }, [current]);
+
+  const buildConfig = (): Record<string, string> => {
+    if (provider === 'porkbun') return { apiKey, secretKey, domain };
+    if (provider === 'digitalocean') return { token, domain };
+    return { token, zoneId, domain };
+  };
+
+  const mutation = useMutation({
+    mutationFn: () => api.settings.saveDns(provider, buildConfig()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      onDone();
+    },
+  });
+
+  const isConfigured = current?.configured ?? false;
+  const hasCredentials = provider === 'porkbun' ? apiKey || isConfigured : token || isConfigured;
+
+  return {
+    provider,
+    token,
+    zoneId,
+    domain,
+    apiKey,
+    secretKey,
+    isConfigured,
+    isPending: mutation.isPending,
+    isError: mutation.isError,
+    mutate: () => mutation.mutate(),
+    canSave: Boolean(hasCredentials && domain),
+    setProvider,
+    setToken,
+    setZoneId,
+    setDomain,
+    setApiKey,
+    setSecretKey,
+    hasToken: Boolean(current?.config?.token),
+    hasApiKey: Boolean(current?.config?.apiKey),
+  };
+}
+
+interface DnsEditFormProps {
+  current: SettingsStatus['dns'] | null;
+  onDone: () => void;
+}
+
+export function DnsEditForm({ current, onDone }: DnsEditFormProps): JSX.Element {
+  const form = useDnsForm(current, onDone);
+
+  return (
+    <div className="space-y-3">
+      <DnsFormFields
+        provider={form.provider}
+        token={form.token}
+        zoneId={form.zoneId}
+        domain={form.domain}
+        apiKey={form.apiKey}
+        secretKey={form.secretKey}
+        hasToken={form.hasToken}
+        hasApiKey={form.hasApiKey}
+        onProviderChange={form.setProvider}
+        onTokenChange={form.setToken}
+        onZoneIdChange={form.setZoneId}
+        onDomainChange={form.setDomain}
+        onApiKeyChange={form.setApiKey}
+        onSecretKeyChange={form.setSecretKey}
+      />
+      <FormActions
+        isPending={form.isPending}
+        canSave={form.canSave}
+        showCancel={form.isConfigured}
+        onSave={form.mutate}
+        onCancel={onDone}
+      />
+      {form.isError && <p className="text-xs text-[#f85149]">Failed to save settings</p>}
+    </div>
+  );
+}
+
+export function DnsDisplay({ current }: { current: SettingsStatus['dns'] | null }): JSX.Element {
+  const [testState, setTestState] = useState<TestState>({ status: 'idle' });
+  const providerLabel = DNS_PROVIDERS.find(p => p.value === current?.provider)?.label;
+
+  const handleTest = async (): Promise<void> => {
+    setTestState({ status: 'testing' });
+    try {
+      const result = await api.settings.testDns();
+      setTestState(
+        result.ok
+          ? { status: 'success' }
+          : { status: 'error', error: result.error || 'Connection test failed' }
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Connection test failed';
+      setTestState({ status: 'error', error: message });
+    }
+  };
+
+  return (
+    <div className="space-y-2 text-xs text-[#8b949e]">
+      {current?.domain && (
+        <p>
+          <span className="text-[#484f58]">Domain:</span> {current.domain}
+        </p>
+      )}
+      <p>
+        <span className="text-[#484f58]">Provider:</span> {providerLabel}
+      </p>
+      {current?.config?.zoneId && (
+        <p>
+          <span className="text-[#484f58]">Zone ID:</span> {current.config.zoneId}
+        </p>
+      )}
+      <p>
+        <span className="text-[#484f58]">Credentials:</span> Saved
+      </p>
+      <TestConnectionButton status={testState.status} error={testState.error} onTest={handleTest} />
+    </div>
+  );
+}

--- a/packages/frontend/src/components/terminal/config/dns-wildcard.tsx
+++ b/packages/frontend/src/components/terminal/config/dns-wildcard.tsx
@@ -1,0 +1,142 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api, type WildcardConfig, type WildcardDetection } from '../../../lib/api';
+import { TERMINAL_COLORS } from '../theme';
+
+interface DnsHeaderProps {
+  isConfigured: boolean;
+  isEditing: boolean;
+  isWildcardMode: boolean;
+  onEdit: () => void;
+}
+
+export function DnsHeader({
+  isConfigured,
+  isEditing,
+  isWildcardMode,
+  onEdit,
+}: DnsHeaderProps): JSX.Element {
+  const title = isWildcardMode ? 'Wildcard Mode' : 'DNS Provider';
+  const badgeText = isWildcardMode ? 'wildcard' : 'configured';
+
+  return (
+    <div className="mb-3 flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-[#c9d1d9]">{title}</span>
+        {(isConfigured || isWildcardMode) && (
+          <span
+            className="rounded px-1.5 py-0.5 text-[10px]"
+            style={{ background: `${TERMINAL_COLORS.success}20`, color: TERMINAL_COLORS.success }}
+          >
+            {badgeText}
+          </span>
+        )}
+      </div>
+      {isConfigured && !isEditing && !isWildcardMode && (
+        <button onClick={onEdit} className="text-xs text-[#58a6ff] hover:underline">
+          Edit
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function DnsDisabledState(): JSX.Element {
+  return (
+    <div className="rounded border border-[#30363d] bg-[#161b22] p-4 opacity-50">
+      <div className="mb-3 flex items-center gap-2">
+        <span className="text-sm font-medium text-[#c9d1d9]">DNS Provider</span>
+        <span className="rounded bg-[#30363d] px-1.5 py-0.5 text-[10px] text-[#8b949e]">
+          step 2
+        </span>
+      </div>
+      <div className="flex items-center justify-center py-6 text-center">
+        <p className="text-xs text-[#8b949e]">Configure proxy first, then set up DNS here</p>
+      </div>
+    </div>
+  );
+}
+
+interface WildcardModeDisplayProps {
+  wildcardConfig?: WildcardConfig | null;
+  wildcardDetection?: WildcardDetection | null;
+}
+
+export function WildcardModeDisplay({
+  wildcardConfig,
+  wildcardDetection,
+}: WildcardModeDisplayProps): JSX.Element {
+  const queryClient = useQueryClient();
+  const domain = wildcardConfig?.domain || wildcardDetection?.domain || 'unknown';
+  const hasCert = wildcardConfig?.certId !== null && wildcardConfig?.certId !== undefined;
+
+  const disableMutation = useMutation({
+    mutationFn: () => api.settings.saveWildcard(false, ''),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      queryClient.invalidateQueries({ queryKey: ['wildcard-detection'] });
+    },
+  });
+
+  return (
+    <div className="rounded border border-[#30363d] bg-[#161b22] p-4">
+      <DnsHeader isConfigured={false} isEditing={false} isWildcardMode={true} onEdit={() => {}} />
+      <div className="space-y-2 text-xs text-[#8b949e]">
+        <p className="font-mono text-[#58a6ff]">*.{domain}</p>
+        <p>
+          <span className="text-[#484f58]">DNS:</span> Skipped (wildcard covers all subdomains)
+        </p>
+        <p>
+          <span className="text-[#484f58]">SSL:</span>{' '}
+          {hasCert ? 'Wildcard certificate linked' : 'No certificate detected'}
+        </p>
+        {!hasCert && (
+          <p className="mt-2 rounded border border-[#f0883e50] bg-[#f0883e15] px-2 py-1.5 text-[#f0883e]">
+            Add *.{domain} SSL cert to NPM for HTTPS
+          </p>
+        )}
+        <button
+          onClick={() => disableMutation.mutate()}
+          disabled={disableMutation.isPending}
+          className="mt-2 text-[#58a6ff] hover:underline disabled:opacity-50"
+        >
+          {disableMutation.isPending ? 'Switching...' : 'Switch to DNS mode'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface WildcardChoiceSectionProps {
+  wildcardDetection: WildcardDetection;
+}
+
+export function WildcardChoiceSection({
+  wildcardDetection,
+}: WildcardChoiceSectionProps): JSX.Element | null {
+  const queryClient = useQueryClient();
+
+  const enableMutation = useMutation({
+    mutationFn: () => api.settings.saveWildcard(true, wildcardDetection.domain || ''),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      queryClient.invalidateQueries({ queryKey: ['wildcard-detection'] });
+    },
+  });
+
+  if (!wildcardDetection.detected) return null;
+
+  return (
+    <div className="mb-4 rounded border border-[#238636] bg-[#23863615] p-3">
+      <p className="mb-2 text-xs text-[#3fb950]">
+        Wildcard detected: <span className="font-mono">{wildcardDetection.fullDomain}</span>
+      </p>
+      <button
+        onClick={() => enableMutation.mutate()}
+        disabled={enableMutation.isPending}
+        className="text-xs text-[#58a6ff] hover:underline disabled:opacity-50"
+      >
+        {enableMutation.isPending ? 'Enabling...' : 'Use wildcard mode (skip DNS setup)'}
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/terminal/config/dns.tsx
+++ b/packages/frontend/src/components/terminal/config/dns.tsx
@@ -1,321 +1,59 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { api, type SettingsStatus } from '../../../lib/api';
-import { FormActions, FormInput, FormSelect } from '../form-components';
-import { TestConnectionButton, type TestState } from '../test-button';
-import { TERMINAL_COLORS } from '../theme';
-import { Tooltip } from '../tooltip';
+import { useState } from 'react';
+import { type SettingsStatus, type WildcardConfig, type WildcardDetection } from '../../../lib/api';
+import { DnsEditForm, DnsDisplay, DNS_PROVIDERS } from './dns-form';
+import {
+  DnsDisabledState,
+  DnsHeader,
+  WildcardChoiceSection,
+  WildcardModeDisplay,
+} from './dns-wildcard';
 
-export const DNS_PROVIDERS = [
-  { value: 'cloudflare', label: 'Cloudflare' },
-  { value: 'netlify', label: 'Netlify' },
-  { value: 'digitalocean', label: 'DigitalOcean' },
-  { value: 'porkbun', label: 'Porkbun' },
-];
+export { DNS_PROVIDERS };
 
 interface DnsConfigSectionProps {
   current: SettingsStatus['dns'] | null;
+  proxyConfigured?: boolean;
+  wildcardConfig?: WildcardConfig | null;
+  wildcardDetection?: WildcardDetection | null;
 }
 
-export function DnsConfigSection({ current }: DnsConfigSectionProps): JSX.Element {
-  const [isEditing, setIsEditing] = useState(!current?.configured);
+export function DnsConfigSection({
+  current,
+  proxyConfigured = true,
+  wildcardConfig,
+  wildcardDetection,
+}: DnsConfigSectionProps): JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const isWildcardMode = wildcardConfig?.enabled ?? false;
   const isConfigured = current?.configured ?? false;
+  const showDnsForm = !isWildcardMode && (isEditing || !isConfigured);
+
+  if (!proxyConfigured) {
+    return <DnsDisabledState />;
+  }
+
+  if (isWildcardMode) {
+    return (
+      <WildcardModeDisplay wildcardConfig={wildcardConfig} wildcardDetection={wildcardDetection} />
+    );
+  }
 
   return (
     <div className="rounded border border-[#30363d] bg-[#161b22] p-4">
       <DnsHeader
         isConfigured={isConfigured}
         isEditing={isEditing}
+        isWildcardMode={false}
         onEdit={() => setIsEditing(true)}
       />
-      {isEditing ? (
+      {!isConfigured && wildcardDetection && (
+        <WildcardChoiceSection wildcardDetection={wildcardDetection} />
+      )}
+      {showDnsForm ? (
         <DnsEditForm current={current} onDone={() => setIsEditing(false)} />
       ) : (
         <DnsDisplay current={current} />
       )}
-    </div>
-  );
-}
-
-interface DnsHeaderProps {
-  isConfigured: boolean;
-  isEditing: boolean;
-  onEdit: () => void;
-}
-
-function DnsHeader({ isConfigured, isEditing, onEdit }: DnsHeaderProps): JSX.Element {
-  return (
-    <div className="mb-3 flex items-center justify-between">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-[#c9d1d9]">DNS Provider</span>
-        {isConfigured && (
-          <span
-            className="rounded px-1.5 py-0.5 text-[10px]"
-            style={{ background: `${TERMINAL_COLORS.success}20`, color: TERMINAL_COLORS.success }}
-          >
-            configured
-          </span>
-        )}
-      </div>
-      {isConfigured && !isEditing && (
-        <Tooltip content="Edit DNS settings">
-          <button onClick={onEdit} className="text-xs text-[#58a6ff] hover:underline">
-            Edit
-          </button>
-        </Tooltip>
-      )}
-    </div>
-  );
-}
-
-interface DnsEditFormProps {
-  current: SettingsStatus['dns'] | null;
-  onDone: () => void;
-}
-
-interface DnsFieldsProps {
-  provider: string;
-  token: string;
-  zoneId: string;
-  domain: string;
-  apiKey: string;
-  secretKey: string;
-  hasToken: boolean;
-  hasApiKey: boolean;
-  onProviderChange: (v: string) => void;
-  onTokenChange: (v: string) => void;
-  onZoneIdChange: (v: string) => void;
-  onDomainChange: (v: string) => void;
-  onApiKeyChange: (v: string) => void;
-  onSecretKeyChange: (v: string) => void;
-}
-
-function DnsFormFields(props: DnsFieldsProps): JSX.Element {
-  const isPorkbun = props.provider === 'porkbun';
-  const needsZone = props.provider === 'cloudflare' || props.provider === 'netlify';
-  const tokenPlaceholder = props.hasToken ? 'Saved' : 'Enter token';
-  const apiKeyPlaceholder = props.hasApiKey ? 'Saved' : 'Enter API key';
-
-  return (
-    <>
-      <FormInput
-        label="Base Domain"
-        placeholder="example.com"
-        value={props.domain}
-        onChange={props.onDomainChange}
-      />
-      <FormSelect
-        label="Provider"
-        value={props.provider}
-        onChange={props.onProviderChange}
-        options={DNS_PROVIDERS}
-      />
-      {isPorkbun ? (
-        <PorkbunFields
-          apiKey={props.apiKey}
-          secretKey={props.secretKey}
-          apiKeyPlaceholder={apiKeyPlaceholder}
-          onApiKeyChange={props.onApiKeyChange}
-          onSecretKeyChange={props.onSecretKeyChange}
-        />
-      ) : (
-        <FormInput
-          label="API Token"
-          type="password"
-          placeholder={tokenPlaceholder}
-          value={props.token}
-          onChange={props.onTokenChange}
-        />
-      )}
-      {needsZone && (
-        <FormInput
-          label="Zone ID"
-          placeholder="Zone ID"
-          value={props.zoneId}
-          onChange={props.onZoneIdChange}
-        />
-      )}
-    </>
-  );
-}
-
-type DnsFormState = {
-  provider: string;
-  token: string;
-  zoneId: string;
-  domain: string;
-  apiKey: string;
-  secretKey: string;
-  isPending: boolean;
-  isError: boolean;
-  mutate: () => void;
-  isConfigured: boolean;
-  canSave: boolean;
-  setProvider: (v: string) => void;
-  setToken: (v: string) => void;
-  setZoneId: (v: string) => void;
-  setDomain: (v: string) => void;
-  setApiKey: (v: string) => void;
-  setSecretKey: (v: string) => void;
-  hasToken: boolean;
-  hasApiKey: boolean;
-};
-
-function useDnsForm(current: SettingsStatus['dns'] | null, onDone: () => void): DnsFormState {
-  const [provider, setProvider] = useState(current?.provider || 'cloudflare');
-  const [token, setToken] = useState('');
-  const [zoneId, setZoneId] = useState(current?.config?.zoneId || '');
-  const [domain, setDomain] = useState(current?.domain || '');
-  const [apiKey, setApiKey] = useState('');
-  const [secretKey, setSecretKey] = useState('');
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    if (current?.provider) setProvider(current.provider);
-    if (current?.config?.zoneId) setZoneId(current.config.zoneId);
-    if (current?.domain) setDomain(current.domain);
-  }, [current]);
-
-  const buildConfig = (): Record<string, string> => {
-    if (provider === 'porkbun') return { apiKey, secretKey, domain };
-    if (provider === 'digitalocean') return { token, domain };
-    return { token, zoneId, domain };
-  };
-
-  const mutation = useMutation({
-    mutationFn: () => api.settings.saveDns(provider, buildConfig()),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
-      onDone();
-    },
-  });
-
-  const isConfigured = current?.configured ?? false;
-  const hasCredentials = provider === 'porkbun' ? apiKey || isConfigured : token || isConfigured;
-
-  return {
-    provider,
-    token,
-    zoneId,
-    domain,
-    apiKey,
-    secretKey,
-    isConfigured,
-    isPending: mutation.isPending,
-    isError: mutation.isError,
-    mutate: () => mutation.mutate(),
-    canSave: Boolean(hasCredentials && domain),
-    setProvider,
-    setToken,
-    setZoneId,
-    setDomain,
-    setApiKey,
-    setSecretKey,
-    hasToken: Boolean(current?.config?.token),
-    hasApiKey: Boolean(current?.config?.apiKey),
-  };
-}
-
-interface PorkbunFieldsProps {
-  apiKey: string;
-  secretKey: string;
-  apiKeyPlaceholder: string;
-  onApiKeyChange: (v: string) => void;
-  onSecretKeyChange: (v: string) => void;
-}
-
-function PorkbunFields(props: PorkbunFieldsProps): JSX.Element {
-  return (
-    <>
-      <FormInput
-        label="API Key"
-        type="password"
-        placeholder={props.apiKeyPlaceholder}
-        value={props.apiKey}
-        onChange={props.onApiKeyChange}
-      />
-      <FormInput
-        label="Secret Key"
-        type="password"
-        placeholder="Enter secret key"
-        value={props.secretKey}
-        onChange={props.onSecretKeyChange}
-      />
-    </>
-  );
-}
-
-function DnsEditForm({ current, onDone }: DnsEditFormProps): JSX.Element {
-  const form = useDnsForm(current, onDone);
-
-  return (
-    <div className="space-y-3">
-      <DnsFormFields
-        provider={form.provider}
-        token={form.token}
-        zoneId={form.zoneId}
-        domain={form.domain}
-        apiKey={form.apiKey}
-        secretKey={form.secretKey}
-        hasToken={form.hasToken}
-        hasApiKey={form.hasApiKey}
-        onProviderChange={form.setProvider}
-        onTokenChange={form.setToken}
-        onZoneIdChange={form.setZoneId}
-        onDomainChange={form.setDomain}
-        onApiKeyChange={form.setApiKey}
-        onSecretKeyChange={form.setSecretKey}
-      />
-      <FormActions
-        isPending={form.isPending}
-        canSave={form.canSave}
-        showCancel={form.isConfigured}
-        onSave={form.mutate}
-        onCancel={onDone}
-      />
-      {form.isError && <p className="text-xs text-[#f85149]">Failed to save settings</p>}
-    </div>
-  );
-}
-
-function DnsDisplay({ current }: { current: SettingsStatus['dns'] | null }): JSX.Element {
-  const [testState, setTestState] = useState<TestState>({ status: 'idle' });
-  const providerLabel = DNS_PROVIDERS.find(p => p.value === current?.provider)?.label;
-
-  const handleTest = async (): Promise<void> => {
-    setTestState({ status: 'testing' });
-    try {
-      const result = await api.settings.testDns();
-      setTestState(
-        result.ok
-          ? { status: 'success' }
-          : { status: 'error', error: result.error || 'Connection test failed' }
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Connection test failed';
-      setTestState({ status: 'error', error: message });
-    }
-  };
-
-  return (
-    <div className="space-y-2 text-xs text-[#8b949e]">
-      {current?.domain && (
-        <p>
-          <span className="text-[#484f58]">Domain:</span> {current.domain}
-        </p>
-      )}
-      <p>
-        <span className="text-[#484f58]">Provider:</span> {providerLabel}
-      </p>
-      {current?.config?.zoneId && (
-        <p>
-          <span className="text-[#484f58]">Zone ID:</span> {current.config.zoneId}
-        </p>
-      )}
-      <p>
-        <span className="text-[#484f58]">Credentials:</span> Saved
-      </p>
-      <TestConnectionButton status={testState.status} error={testState.error} onTest={handleTest} />
     </div>
   );
 }

--- a/packages/frontend/src/components/terminal/editable/subdomain.tsx
+++ b/packages/frontend/src/components/terminal/editable/subdomain.tsx
@@ -141,7 +141,8 @@ export function EditableSubdomain(props: EditableSubdomainProps): JSX.Element {
 
   if (!value) return <EmptyState onEdit={startEdit} />;
 
-  const fullDomain = baseDomain ? `${value}.${baseDomain}` : value;
+  const looksLikeFullDomain = value.includes('.') && value.split('.').length >= 2;
+  const fullDomain = looksLikeFullDomain ? value : baseDomain ? `${value}.${baseDomain}` : value;
   if (isExposed) return <ExposedLink domain={fullDomain} protocol={protocol || null} />;
 
   return (

--- a/packages/frontend/src/components/terminal/service-card.tsx
+++ b/packages/frontend/src/components/terminal/service-card.tsx
@@ -21,6 +21,7 @@ interface TerminalServiceCardProps {
   isRetrySslPending?: boolean;
   scanTrigger?: number;
   bulkStatus?: { online: boolean; protocol: string | null };
+  isWildcardMode: boolean;
 }
 export function TerminalServiceCard(props: TerminalServiceCardProps): JSX.Element {
   const {
@@ -37,6 +38,7 @@ export function TerminalServiceCard(props: TerminalServiceCardProps): JSX.Elemen
     isRetrySslPending = false,
     scanTrigger,
     bulkStatus,
+    isWildcardMode,
   } = props;
   const [showDelete, setShowDelete] = useState(false);
   const [protocol, setProtocol] = useState<'https' | 'http' | null>(null);
@@ -80,6 +82,7 @@ export function TerminalServiceCard(props: TerminalServiceCardProps): JSX.Elemen
         isRetrySslPending={isRetrySslPending}
         scanTrigger={scanTrigger}
         bulkStatus={bulkStatus}
+        isWildcardMode={isWildcardMode}
       />
     </div>
   );
@@ -145,6 +148,7 @@ interface CardFooterProps {
   isRetrySslPending: boolean;
   scanTrigger?: number;
   bulkStatus?: { online: boolean; protocol: string | null };
+  isWildcardMode: boolean;
 }
 function CardFooter(props: CardFooterProps): JSX.Element {
   const {
@@ -162,6 +166,7 @@ function CardFooter(props: CardFooterProps): JSX.Element {
     isRetrySslPending,
     scanTrigger,
     bulkStatus,
+    isWildcardMode,
   } = props;
   return (
     <div className="flex items-center justify-between">
@@ -172,6 +177,7 @@ function CardFooter(props: CardFooterProps): JSX.Element {
         onProtocolChange={onProtocolChange}
         scanTrigger={scanTrigger}
         bulkStatus={bulkStatus}
+        isWildcardMode={isWildcardMode}
       />
       <div className="flex items-center gap-2">
         {isExposed && service.sslPending && (

--- a/packages/frontend/src/components/terminal/settings-panel.tsx
+++ b/packages/frontend/src/components/terminal/settings-panel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { type SettingsStatus, api } from '../../lib/api';
 import { ConfirmDialog } from './confirm-dialog';
 import { DnsConfigSection, ProxyConfigSection } from './config';
@@ -45,6 +46,14 @@ interface SettingsPanelProps {
 
 export function SettingsPanel({ settings, isOpen, onClose }: SettingsPanelProps): JSX.Element {
   const visClass = isOpen ? 'max-h-[60vh] opacity-100' : 'max-h-0 opacity-0';
+  const proxyConfigured = settings?.proxy?.configured ?? false;
+
+  const { data: wildcardDetection } = useQuery({
+    queryKey: ['wildcard-detection'],
+    queryFn: () => api.settings.detectWildcard(),
+    enabled: proxyConfigured && isOpen,
+    staleTime: 30000,
+  });
 
   return (
     <div
@@ -53,8 +62,13 @@ export function SettingsPanel({ settings, isOpen, onClose }: SettingsPanelProps)
       <div className="p-6 pb-8">
         <PanelHeader onClose={onClose} />
         <div className="grid gap-6 md:grid-cols-2">
-          <DnsConfigSection current={settings?.dns ?? null} />
           <ProxyConfigSection current={settings?.proxy ?? null} />
+          <DnsConfigSection
+            current={settings?.dns ?? null}
+            proxyConfigured={proxyConfigured}
+            wildcardConfig={settings?.wildcard ?? null}
+            wildcardDetection={wildcardDetection ?? null}
+          />
         </div>
       </div>
     </div>

--- a/packages/frontend/src/components/terminal/status-bar-components.tsx
+++ b/packages/frontend/src/components/terminal/status-bar-components.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { Tooltip } from './tooltip';
+
+const ORPHAN_BADGE_KEY = 'autoxpose:orphan-badge-minimized';
+
+export function OrphanBadge({
+  count,
+  onClick,
+}: {
+  count: number;
+  onClick: () => void;
+}): JSX.Element | null {
+  const [isMinimized, setIsMinimized] = useState(() => {
+    try {
+      return localStorage.getItem(ORPHAN_BADGE_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(ORPHAN_BADGE_KEY, String(isMinimized));
+    } catch {
+      return;
+    }
+  }, [isMinimized]);
+
+  if (count === 0) return null;
+
+  const handleMinimize = (e: React.MouseEvent): void => {
+    e.stopPropagation();
+    setIsMinimized(true);
+  };
+
+  const handleExpand = (e: React.MouseEvent): void => {
+    e.stopPropagation();
+    setIsMinimized(false);
+  };
+
+  if (isMinimized) {
+    return (
+      <Tooltip content="Container stopped but DNS/proxy records still exist">
+        <button
+          onClick={handleExpand}
+          className="h-2 w-2 rounded-full bg-[#f0883e] transition-transform hover:scale-125"
+          aria-label="Expand orphaned services badge"
+        />
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip content="Container stopped but DNS/proxy records still exist">
+      <button
+        onClick={onClick}
+        className="group flex items-center gap-1.5 rounded bg-[#f0883e20] px-2 py-1 transition-all hover:bg-[#f0883e30]"
+      >
+        <span className="text-xs font-medium text-[#f0883e]">{count} orphaned</span>
+        <button
+          onClick={handleMinimize}
+          className="flex h-3.5 w-3.5 items-center justify-center rounded text-[#f0883e] opacity-0 transition-opacity hover:bg-[#f0883e40] group-hover:opacity-100"
+          aria-label="Minimize badge"
+        >
+          −
+        </button>
+      </button>
+    </Tooltip>
+  );
+}
+
+export function NetworkWarning({
+  message,
+  dismissible,
+  onDismiss,
+  severity,
+}: {
+  message: string;
+  dismissible: boolean;
+  onDismiss: () => void;
+  severity: 'error' | 'warning' | 'info';
+}): JSX.Element {
+  const colors = {
+    error: { text: 'text-[#f85149]', bg: 'bg-[#f8514915]', border: 'border-[#f8514950]' },
+    warning: { text: 'text-[#f0883e]', bg: 'bg-[#f0883e15]', border: 'border-[#f0883e50]' },
+    info: { text: 'text-[#58a6ff]', bg: 'bg-[#58a6ff15]', border: 'border-[#58a6ff50]' },
+  };
+
+  const icons = {
+    error: '\u2717',
+    warning: '\u26A0',
+    info: '\u2139',
+  };
+
+  const { text, bg, border } = colors[severity];
+  const icon = icons[severity];
+
+  return (
+    <div
+      className={`flex items-center justify-between gap-3 rounded border px-3 py-2 ${text} ${bg} ${border}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-sm">{icon}</span>
+        <span className="text-xs">{message}</span>
+      </div>
+      {dismissible && (
+        <Tooltip content="Dismiss">
+          <button
+            onClick={onDismiss}
+            className={`rounded px-2 py-1 text-[10px] transition-colors hover:bg-[#30363d] ${text}`}
+            aria-label="Dismiss warning"
+          >
+            ✕
+          </button>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -66,11 +66,26 @@ export interface PlatformInfo {
   os: string;
 }
 
+export interface WildcardConfig {
+  enabled: boolean;
+  domain: string | null;
+  certId: number | null;
+  detected: boolean;
+}
+
+export interface WildcardDetection {
+  detected: boolean;
+  domain: string | null;
+  certId: number | null;
+  fullDomain: string | null;
+}
+
 export interface SettingsStatus {
   dns: DnsStatus;
   proxy: ProviderStatus;
   network?: NetworkStatus;
   platform?: PlatformInfo;
+  wildcard?: WildcardConfig;
 }
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
@@ -229,6 +244,17 @@ export const api = {
       request<{ success: boolean }>('/settings/import', {
         method: 'POST',
         body: JSON.stringify(data),
+      }),
+    detectWildcard: (): Promise<WildcardDetection> =>
+      request<WildcardDetection>('/settings/wildcard/detect'),
+    getWildcard: (): Promise<WildcardConfig> => request<WildcardConfig>('/settings/wildcard'),
+    saveWildcard: (
+      enabled: boolean,
+      domain: string
+    ): Promise<{ success: boolean; config: WildcardConfig }> =>
+      request<{ success: boolean; config: WildcardConfig }>('/settings/wildcard', {
+        method: 'POST',
+        body: JSON.stringify({ enabled, domain }),
       }),
   },
 };

--- a/packages/frontend/src/pages/Terminal.tsx
+++ b/packages/frontend/src/pages/Terminal.tsx
@@ -141,8 +141,10 @@ function useDashboardState(
   canExposeReason: string;
   exposedCount: number;
   connectionStatus: ConnectionStatus;
+  isWildcardMode: boolean;
 } {
-  const dnsOk = settings?.dns?.configured ?? false;
+  const isWildcardMode = settings?.wildcard?.enabled ?? false;
+  const dnsOk = isWildcardMode || (settings?.dns?.configured ?? false);
   const proxyOk = settings?.proxy?.configured ?? false;
   const serverIpState = settings?.network?.serverIpState ?? 'missing';
   const serverIpBlocking = ['missing', 'invalid', 'placeholder'].includes(serverIpState);
@@ -162,6 +164,7 @@ function useDashboardState(
     canExposeReason,
     exposedCount,
     connectionStatus,
+    isWildcardMode,
   };
 }
 
@@ -248,6 +251,11 @@ interface DashboardMainProps {
 }
 
 function DashboardMain(props: DashboardMainProps): JSX.Element {
+  const baseDomain =
+    props.settings?.wildcard?.enabled && props.settings?.wildcard?.domain
+      ? props.settings.wildcard.domain
+      : (props.settings?.dns?.domain ?? null);
+
   return (
     <>
       <MainContent
@@ -257,7 +265,7 @@ function DashboardMain(props: DashboardMainProps): JSX.Element {
         activeService={props.activeService}
         loadingId={getLoadingId(props.state.streamState, props.state.deletingServiceId)}
         settingsData={props.settings}
-        baseDomain={props.settings?.dns?.domain ?? null}
+        baseDomain={baseDomain}
         canExpose={props.dashboardState.canExpose}
         canExposeReason={
           props.dashboardState.canExpose ? undefined : props.dashboardState.canExposeReason
@@ -265,6 +273,7 @@ function DashboardMain(props: DashboardMainProps): JSX.Element {
         setShortcutsOpen={props.setShortcutsOpen}
         orphanCount={props.orphanCount}
         onOrphansClick={() => props.setOrphansOpen(true)}
+        isWildcardMode={props.dashboardState.isWildcardMode}
       />
       <ConfirmDialogs
         action={props.state.confirmAction}
@@ -298,6 +307,7 @@ interface MainContentProps {
   setShortcutsOpen: (open: boolean) => void;
   orphanCount: number;
   onOrphansClick: () => void;
+  isWildcardMode: boolean;
 }
 
 function MainContent({
@@ -313,6 +323,7 @@ function MainContent({
   setShortcutsOpen,
   orphanCount,
   onOrphansClick,
+  isWildcardMode,
 }: MainContentProps): JSX.Element {
   return (
     <div className="flex flex-1 overflow-hidden">
@@ -334,6 +345,7 @@ function MainContent({
             canExpose={canExpose}
             canExposeReason={canExposeReason}
             onScan={actions.handleScan}
+            isWildcardMode={isWildcardMode}
           />
         </div>
         <SettingsPanel

--- a/packages/frontend/src/pages/terminal/command-engine.ts
+++ b/packages/frontend/src/pages/terminal/command-engine.ts
@@ -73,6 +73,7 @@ export async function executeCommand(raw: string, ctx: CommandContext): Promise<
   if (parsed.name === 'test') return testResult(parsed.arg);
   if (parsed.name === 'open') return openResult(parsed.arg, ctx.services, ctx.settings);
   if (parsed.name === 'scan') return scanResult();
+  if (parsed.name === 'wildcard') return wildcardResult(parsed.arg, ctx.settings);
   return { lines: [{ text: "Unknown command. Try 'help'.", tone: 'error' }] };
 }
 
@@ -96,6 +97,7 @@ function helpResult(arg: string): CommandResult {
     { cmd: 'clear', desc: 'clear terminal output' },
     { cmd: 'iamfeelinglucky', desc: 'random tip or quip' },
     { cmd: 'scan', desc: 'scan for services' },
+    { cmd: 'wildcard', desc: 'wildcard status | enable <domain> | disable' },
   ];
   const key = arg.trim().toLowerCase();
   if (!key) {
@@ -129,7 +131,8 @@ function listLines(services: ServiceRecord[]): OutputLine[] {
 }
 
 function statusLine(services: ServiceRecord[], settings: SettingsStatus | undefined): OutputLine {
-  const dnsOk = settings?.dns?.configured ? 'ok' : 'missing';
+  const isWildcard = settings?.wildcard?.enabled ?? false;
+  const dnsOk = isWildcard ? 'wildcard' : settings?.dns?.configured ? 'ok' : 'missing';
   const proxyOk = settings?.proxy?.configured ? 'ok' : 'missing';
   const count = `${services.filter(s => s.enabled).length}/${services.length} exposed`;
   const warnings: string[] = [];
@@ -208,7 +211,75 @@ function scanResult(): CommandResult {
 function buildUrl(service: ServiceRecord, settings: SettingsStatus | undefined): string | null {
   const base = service.subdomain || '';
   if (!base) return null;
-  const domain =
-    base.includes('.') || !settings?.dns?.domain ? base : `${base}.${settings.dns.domain}`;
+  const baseDomain =
+    settings?.wildcard?.enabled && settings?.wildcard?.domain
+      ? settings.wildcard.domain
+      : settings?.dns?.domain;
+  const domain = base.includes('.') || !baseDomain ? base : `${base}.${baseDomain}`;
   return domain.startsWith('http') ? domain : `https://${domain}`;
+}
+
+function wildcardStatusResult(settings: SettingsStatus | undefined): CommandResult {
+  const enabled = settings?.wildcard?.enabled ?? false;
+  const domain = settings?.wildcard?.domain;
+  const hasCert = settings?.wildcard?.certId !== null && settings?.wildcard?.certId !== undefined;
+
+  if (!enabled) {
+    return { lines: [{ text: 'Wildcard mode: disabled', tone: 'muted' }] };
+  }
+
+  const certStatus = hasCert ? 'linked' : 'not detected';
+  return {
+    lines: [
+      { text: `Wildcard mode: enabled`, tone: 'success' },
+      { text: `Domain: *.${domain}`, tone: 'info' },
+      { text: `Certificate: ${certStatus}`, tone: hasCert ? 'info' : 'muted' },
+    ],
+  };
+}
+
+async function wildcardEnableResult(domain: string | undefined): Promise<CommandResult> {
+  if (!domain) {
+    return { lines: [{ text: 'Usage: wildcard enable <domain>', tone: 'error' }] };
+  }
+  try {
+    await api.settings.saveWildcard(true, domain);
+    return {
+      lines: [
+        { text: `Wildcard mode enabled for *.${domain}`, tone: 'success' },
+        { text: 'DNS creation will be skipped for new exposures.', tone: 'muted' },
+      ],
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to enable wildcard mode';
+    return { lines: [{ text: msg, tone: 'error' }] };
+  }
+}
+
+async function wildcardDisableResult(): Promise<CommandResult> {
+  try {
+    await api.settings.saveWildcard(false, '');
+    return {
+      lines: [
+        { text: 'Wildcard mode disabled. DNS will be created per service.', tone: 'success' },
+      ],
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to disable wildcard mode';
+    return { lines: [{ text: msg, tone: 'error' }] };
+  }
+}
+
+async function wildcardResult(
+  arg: string,
+  settings: SettingsStatus | undefined
+): Promise<CommandResult> {
+  const parts = arg.trim().split(' ');
+  const subcommand = parts[0]?.toLowerCase() || 'status';
+
+  if (subcommand === 'status') return wildcardStatusResult(settings);
+  if (subcommand === 'enable') return wildcardEnableResult(parts[1]);
+  if (subcommand === 'disable') return wildcardDisableResult();
+
+  return { lines: [{ text: 'Usage: wildcard status | enable <domain> | disable', tone: 'error' }] };
 }

--- a/packages/frontend/src/pages/terminal/command-lucky.ts
+++ b/packages/frontend/src/pages/terminal/command-lucky.ts
@@ -39,6 +39,9 @@ const LUCKY_LINES = [
   'The most secure server is the one that is unplugged. It is also the most useless.',
   'Remember when you started a homelab to save money? Good times.',
   'Feeling lucky? Try entering the Konami code.',
+  'Wildcard mode: because life is too short to create DNS records one at a time.',
+  'With great wildcard power comes great subdomain responsibility.',
+  'Your wildcard cert is doing all the heavy lifting. Give it some appreciation.',
 ];
 
 export function getLuckyLine(): string {

--- a/packages/frontend/src/pages/terminal/content-area.tsx
+++ b/packages/frontend/src/pages/terminal/content-area.tsx
@@ -18,6 +18,7 @@ interface ContentAreaProps {
   canExposeReason?: string;
   settingsData: Awaited<ReturnType<typeof import('../../lib/api').api.settings.status>> | undefined;
   onScan: () => void;
+  isWildcardMode: boolean;
 }
 
 export function ContentArea(props: ContentAreaProps): JSX.Element {
@@ -32,6 +33,7 @@ export function ContentArea(props: ContentAreaProps): JSX.Element {
     canExposeReason,
     settingsData,
     onScan,
+    isWildcardMode,
   } = props;
 
   const { selectedTags, setSelectedTags, tagCounts, filteredServices } = useTagFilters(services);
@@ -60,6 +62,7 @@ export function ContentArea(props: ContentAreaProps): JSX.Element {
         onScan={onScan}
         retrySslPending={state.retrySslMutation.isPending}
         scanTrigger={state.scanTrigger}
+        isWildcardMode={isWildcardMode}
       />
       <ProgressSection
         streamState={state.streamState}

--- a/packages/frontend/src/pages/terminal/service-grid.tsx
+++ b/packages/frontend/src/pages/terminal/service-grid.tsx
@@ -18,6 +18,7 @@ interface ServiceGridProps {
   onScan: () => void;
   retrySslPending: boolean;
   scanTrigger: number;
+  isWildcardMode: boolean;
 }
 
 export function ServiceGrid({
@@ -35,6 +36,7 @@ export function ServiceGrid({
   onScan,
   retrySslPending,
   scanTrigger,
+  isWildcardMode,
 }: ServiceGridProps): JSX.Element {
   const { statusMap, checkServices } = useBulkStatusCheck(scanTrigger);
 
@@ -72,6 +74,7 @@ export function ServiceGrid({
             isRetrySslPending={retrySslPending}
             scanTrigger={scanTrigger}
             bulkStatus={statusMap[service.id]}
+            isWildcardMode={isWildcardMode}
           />
         );
       })}


### PR DESCRIPTION
- **Wildcard Mode**: Skip individual DNS record creation when using wildcard DNS and SSL certificates
  - Auto-detect `*.domain.com` certificates from NPM
  - DNS credentials no longer required when wildcard mode is active

- **Portracker Integration**: Expose data for portracker to display publicly accessible services
  - `/api/services?includeExternal=true` returns all exposed services including manually configured ones