### PR TITLE
fix: restrict CORS to same-origin to prevent secret exposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to autoxpose will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **CORS**: Restrict cross-origin requests to same-origin by default so other websites cannot read your settings or provider credentials. Set `CORS_ORIGIN` to allow specific origins if needed.
+
 ## [0.4.1] - 2026-03-18
 
 ### Fixed

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -20,7 +20,10 @@ const __dirname = dirname(__filename);
 export async function createServer(_config: AppConfig, ctx: AppContext): Promise<FastifyInstance> {
   const server = Fastify({ logger: false });
 
-  await server.register(cors, { origin: true });
+  const corsOrigin = process.env.CORS_ORIGIN;
+  await server.register(cors, {
+    origin: corsOrigin ? corsOrigin.split(',').map(value => value.trim()) : false,
+  });
 
   server.addContentTypeParser(
     ['application/x-www-form-urlencoded', 'text/plain'],


### PR DESCRIPTION
### Security

- **CORS**: Restrict cross-origin requests to same-origin by default so other websites cannot read your settings or provider credentials
  - The dashboard is served from the same origin as the API, so normal use is unaffected
  - Set `CORS_ORIGIN` to allow specific origins if needed