### PR TITLE
fix: grant docker socket access via entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to autoxpose will be documented in this file.
 
 - **CORS**: Restrict cross-origin requests to same-origin by default so other websites cannot read your settings or provider credentials. Set `CORS_ORIGIN` to allow specific origins if needed.
 
+### Fixed
+
+- **Docker Discovery**: Automatically grant the container access to the Docker socket at startup, so container discovery works without manually adding `group_add` to your compose file. The app still runs as a non-root user.
+
 ## [0.4.1] - 2026-03-18
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
+RUN apk add --no-cache su-exec
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 autoxpose
 
@@ -33,7 +35,8 @@ COPY --from=builder --chown=autoxpose:nodejs /app/packages/frontend/dist ./publi
 
 RUN mkdir -p /app/packages/backend/data && chown autoxpose:nodejs /app/packages/backend/data
 
-USER autoxpose
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -41,4 +44,5 @@ ENV PORT=3000
 EXPOSE 3000
 
 WORKDIR /app/packages/backend
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+  SOCKET="/var/run/docker.sock"
+  if [ -S "$SOCKET" ]; then
+    SOCKET_GID="$(stat -c '%g' "$SOCKET" 2>/dev/null || echo 0)"
+    if [ "$SOCKET_GID" != "0" ]; then
+      GROUP_NAME="$(awk -F: -v gid="$SOCKET_GID" '$3 == gid {print $1; exit}' /etc/group)"
+      if [ -z "$GROUP_NAME" ]; then
+        GROUP_NAME="dockerhost"
+        addgroup -g "$SOCKET_GID" "$GROUP_NAME" 2>/dev/null || true
+      fi
+      addgroup autoxpose "$GROUP_NAME" 2>/dev/null || true
+    fi
+  fi
+
+  chown autoxpose:nodejs /app/packages/backend/data 2>/dev/null || true
+
+  exec su-exec autoxpose "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
### Fixed

- **Docker Discovery**: Grant the container access to the Docker socket automatically at startup, so discovery works without adding `group_add` to your compose file
  - The app still runs as a non-root user; the entrypoint detects the socket group, grants access, then drops privileges
  - Running the container with an explicit non-root `--user` skips the group setup and starts the app directly