### PR TITLE
fix: run initial discovery reconcile on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to autoxpose will be documented in this file.
 
 - **Docker Discovery**: Automatically grant the container access to the Docker socket at startup, so container discovery works without manually adding `group_add` to your compose file. The app still runs as a non-root user.
 
+- **Discovery**: Detect containers that are already running when autoxpose starts, instead of only picking them up on later Docker events.
+
 ## [0.4.1] - 2026-03-18
 
 ### Fixed

--- a/packages/backend/src/core/context.ts
+++ b/packages/backend/src/core/context.ts
@@ -126,6 +126,9 @@ export function createAppContext(
       (containerId: string) => handleContainerRemoved(containerId, deps)
     );
     logger.info('Docker watcher started');
+    fullReconcile(deps).catch((err: unknown) => {
+      logger.error({ err }, 'Initial discovery reconcile failed');
+    });
   };
 
   return { ...core, discovery, changeTracker, lanIp: resolvedLanIp, startWatcher };


### PR DESCRIPTION
### Fixed

- **Discovery**: Detect containers that are already running when autoxpose starts, instead of only picking them up on later Docker events